### PR TITLE
ushell: convert to use `embedded-io` traits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,6 +61,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
 name = "hash32"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -138,7 +144,7 @@ dependencies = [
 name = "ushell"
 version = "0.3.6"
 dependencies = [
- "embedded-hal",
+ "embedded-io",
  "heapless",
  "nb 1.0.0",
  "uluru",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,5 @@ heapless = "0.7.1"
 nb = "1.0.0"
 uluru = "2.1.1"
 
-[dependencies.embedded-hal]
-features = ["unproven"]
-version = "0.2.4"
+[dependencies.embedded-io]
+version = "0.6.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,13 @@
 #![no_std]
 #![deny(unsafe_code)]
 
-extern crate embedded_hal as hal;
+extern crate embedded_io as io;
 extern crate heapless;
 extern crate nb;
 extern crate uluru;
 
 use core::{fmt, marker::PhantomData, str::Utf8Error};
-use hal::serial::{Read, Write};
+use io::{Error as IoError, ErrorKind, ErrorType, Read, Write};
 
 pub mod autocomplete;
 pub mod control;
@@ -17,68 +17,76 @@ mod shell;
 
 pub use shell::*;
 
-pub enum ShellError<S>
-where
-    S: Read<u8> + Write<u8>,
-{
-    ReadError(<S as Read<u8>>::Error),
-    WriteError(<S as Write<u8>>::Error),
+pub enum ShellError {
+    ReadError(ErrorKind),
+    WriteError(ErrorKind),
     FormatError(fmt::Error),
     BadInputError(Utf8Error),
     WouldBlock,
     HistoryError,
 }
 
-impl<S> From<fmt::Error> for ShellError<S>
-where
-    S: Read<u8> + Write<u8>,
-{
+impl fmt::Display for ShellError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ReadError(err) => write!(f, "Read error: {err:?}"),
+            Self::WriteError(err) => write!(f, "Write error: {err:?}"),
+            Self::FormatError(err) => write!(f, "Format error: {err}"),
+            Self::BadInputError(err) => write!(f, "I/O error: {err}"),
+            Self::WouldBlock => write!(f, "I/O transaction would block"),
+            Self::HistoryError => write!(f, "Shell history error"),
+        }
+    }
+}
+
+impl fmt::Debug for ShellError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self, f)
+    }
+}
+
+impl From<fmt::Error> for ShellError {
     fn from(err: fmt::Error) -> Self {
         ShellError::FormatError(err)
     }
 }
 
-impl<S> From<Utf8Error> for ShellError<S>
-where
-    S: Read<u8> + Write<u8>,
-{
+impl From<Utf8Error> for ShellError {
     fn from(err: Utf8Error) -> Self {
         ShellError::BadInputError(err)
     }
 }
 
-pub enum SpinError<S, E>
-where
-    S: Read<u8> + Write<u8>,
-{
-    ShellError(ShellError<S>),
+pub enum SpinError<E> {
+    ShellError(ShellError),
     EnvironmentError(E),
 }
 
-impl<S, E> From<ShellError<S>> for SpinError<S, E>
-where
-    S: Read<u8> + Write<u8>,
-{
-    fn from(err: ShellError<S>) -> Self {
+impl<E> From<ShellError> for SpinError<E> {
+    fn from(err: ShellError) -> Self {
         SpinError::ShellError(err)
     }
 }
 
-impl<S, E> From<fmt::Error> for SpinError<S, E>
-where
-    S: Read<u8> + Write<u8>,
-{
+impl<E> From<fmt::Error> for SpinError<E> {
     fn from(err: fmt::Error) -> Self {
         SpinError::ShellError(err.into())
     }
 }
 
-impl<S, E> From<Utf8Error> for SpinError<S, E>
-where
-    S: Read<u8> + Write<u8>,
-{
+impl<E> From<Utf8Error> for SpinError<E> {
     fn from(err: Utf8Error) -> Self {
         SpinError::ShellError(err.into())
+    }
+}
+
+impl IoError for ShellError {
+    fn kind(&self) -> ErrorKind {
+        match self {
+            Self::ReadError(err) => *err,
+            Self::WriteError(err) => *err,
+            _ => ErrorKind::Other,
+        }
     }
 }
 
@@ -89,7 +97,7 @@ pub enum Input<'a> {
 
 pub trait Environment<S, A, H, E, const CMD_LEN: usize>
 where
-    S: Read<u8> + Write<u8>,
+    S: Read + Write,
     A: autocomplete::Autocomplete<CMD_LEN>,
     H: history::History<CMD_LEN>,
 {
@@ -98,18 +106,22 @@ where
         shell: &mut UShell<S, A, H, CMD_LEN>,
         cmd: &str,
         args: &str,
-    ) -> SpinResult<S, E>;
+    ) -> SpinResult<E>;
 
-    fn control(&mut self, shell: &mut UShell<S, A, H, CMD_LEN>, code: u8) -> SpinResult<S, E>;
+    fn control(&mut self, shell: &mut UShell<S, A, H, CMD_LEN>, code: u8) -> SpinResult<E>;
 }
 
-pub struct Serial<W, TX: Write<W>, RX: Read<W>> {
-    w: PhantomData<W>,
+pub struct Serial<TX: Write, RX: Read> {
+    w: PhantomData<u8>,
     tx: TX,
     rx: RX,
 }
 
-impl<W, TX: Write<W>, RX: Read<W>> Serial<W, TX, RX> {
+impl<TX: Write, RX: Read> ErrorType for Serial<TX, RX> {
+    type Error = ShellError;
+}
+
+impl<TX: Write, RX: Read> Serial<TX, RX> {
     pub fn from_parts(tx: TX, rx: RX) -> Self {
         Self {
             tx,
@@ -131,22 +143,18 @@ impl<W, TX: Write<W>, RX: Read<W>> Serial<W, TX, RX> {
     }
 }
 
-impl<W, TX: Write<W>, RX: Read<W>> Write<W> for Serial<W, TX, RX> {
-    type Error = TX::Error;
-
-    fn write(&mut self, word: W) -> nb::Result<(), Self::Error> {
-        self.tx.write(word)
+impl<TX: Write, RX: Read> Write for Serial<TX, RX> {
+    fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+        self.tx.write(buf).map_err(|err| Self::Error::WriteError(err.kind()))
     }
 
-    fn flush(&mut self) -> nb::Result<(), Self::Error> {
-        self.tx.flush()
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        self.tx.flush().map_err(|err| Self::Error::WriteError(err.kind()))
     }
 }
 
-impl<W, TX: Write<W>, RX: Read<W>> Read<W> for Serial<W, TX, RX> {
-    type Error = RX::Error;
-
-    fn read(&mut self) -> nb::Result<W, Self::Error> {
-        self.rx.read()
+impl<TX: Write, RX: Read> Read for Serial<TX, RX> {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+        self.rx.read(buf).map_err(|err| Self::Error::ReadError(err.kind()))
     }
 }


### PR DESCRIPTION
Converts the entire library to use the `embedded_io` traits.

These are the modern versions of the `embedded_hal::serial` equivalents.

Completely breaks the public API, requiring a minor version bump, since no stable API has been released. Even though the API is broken, external users should require minimal effort to upgrade.